### PR TITLE
feat: Add cat, history, sysinfo commands and Hangman game

### DIFF
--- a/src/utils/commands.test.ts
+++ b/src/utils/commands.test.ts
@@ -16,24 +16,66 @@ const localStorageMock = (() => {
 })();
 Object.defineProperty(globalThis, 'localStorage', {
   value: localStorageMock,
-  writable: true
+  writable: true,
+  configurable: true // Make it configurable
 });
 
-// Mock window object for hostname
-const windowMock = {
+// Mock window object properties - with values expected by sysinfo tests
+const baseWindowMock = {
   location: {
-    hostname: 'testhost'
-  }
+    hostname: 'testhost', // Used by sysinfo & global hostname const
+  },
+  screen: {
+    width: 1440, // For sysinfo test
+    height: 900,  // For sysinfo test
+  },
+  innerWidth: 1280, // For sysinfo test
+  innerHeight: 800, // For sysinfo test
+  document: {
+    title: 'Test Terminal SYSINFO', // For sysinfo test
+  },
 };
-Object.defineProperty(globalThis, 'window', {
-  value: windowMock,
-  writable: true
+// Ensure window is defined and extendable
+if (typeof globalThis.window === 'undefined') {
+  Object.defineProperty(globalThis, 'window', {
+    value: baseWindowMock,
+    writable: true,
+    configurable: true, // Allow redefinition if needed by other tests or setup
+  });
+} else { // If already defined (e.g. by jsdom via another test file's environment)
+  // Augment existing window mock, being careful not to overwrite essential jsdom props
+  Object.assign(globalThis.window, baseWindowMock);
+  if (!globalThis.window.document) globalThis.window.document = baseWindowMock.document;
+  if (!globalThis.window.screen) globalThis.window.screen = baseWindowMock.screen;
+}
+
+
+// Mock navigator object
+const navigatorMock = {
+  platform: 'TestPlatform SYSINFO', // For sysinfo test fallback
+  userAgentData: {
+    platform: 'TestUAPlatform SYSINFO', // For sysinfo test primary
+  },
+};
+Object.defineProperty(globalThis, 'navigator', {
+  value: navigatorMock,
+  writable: true,
+  configurable: true,
 });
+
+
+// Mock Date.now() globally BEFORE commands.ts (and its startTime) is imported
+const initialMockedDateNow = 1700000000000; // This will be value for startTime in commands.ts
+let globalDateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(initialMockedDateNow);
 
 
 // THEN import vitest utilities AND THEN vi.mock calls
-import { describe, it, expect, beforeEach, vi, beforeAll } from 'vitest';
+import { describe, it, expect, beforeEach, vi, beforeAll, afterEach } from 'vitest';
 import * as filesystemModuleOriginal from './filesystem'; // Keep original type, but we mock it
+// Import 'get' for reading store value.
+import { get } from 'svelte/store';
+// actualThemeStore will be imported dynamically in sysinfo's beforeEach
+import type { Theme } from '../interfaces/theme'; // For theme type
 
 // Mock the entire filesystem module
 vi.mock('./filesystem', async (importOriginal) => {
@@ -185,10 +227,49 @@ let commands: any;
 let filesystemModule: typeof filesystemModuleOriginal & { __resetMockFsState: (newRoot?: filesystemModuleOriginal.Directory) => void };
 
 beforeAll(async () => {
-  // Reset modules to ensure mocks are freshly applied and localStorage is set.
+  // Reset modules to ensure mocks are freshly applied and globals are set for the fresh module load.
   vi.resetModules();
-  // Re-assign mock for localStorage for this specific module loading context if needed, though top-level should be fine.
-  Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+  // Ensure all global mocks are firmly in place before commands.ts (and its dependencies) are imported.
+  // Ensure all global mocks are firmly in place with specific values for this test file's context
+  // AFTER vi.resetModules() and BEFORE the application code (commands.ts) is imported.
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: localStorageMock,
+    writable: true,
+    configurable: true
+  });
+
+  // Define the complete window structure expected by sysinfo, directly here.
+  const freshWindowMock = {
+    location: { hostname: 'testhost' },
+    screen: { width: 1440, height: 900 },
+    innerWidth: 1280,
+    innerHeight: 800,
+    document: { title: 'Test Terminal SYSINFO' },
+  };
+  Object.defineProperty(globalThis, 'window', {
+    value: freshWindowMock,
+    writable: true,
+    configurable: true
+  });
+
+  const freshNavigatorMock = {
+    platform: 'TestPlatform SYSINFO',
+    userAgentData: { platform: 'TestUAPlatform SYSINFO' },
+  };
+  Object.defineProperty(globalThis, 'navigator', {
+    value: freshNavigatorMock,
+    writable: true,
+    configurable: true
+  });
+  // Also explicitly define document on globalThis for environments that might need it
+  Object.defineProperty(globalThis, 'document', {
+    value: freshWindowMock.document, // from freshWindowMock
+    writable: true,
+    configurable: true
+  });
+
+  // globalDateNowSpy (for Date.now) is already set globally and should persist.
 
   const commandsModule = await import('./commands');
   commands = commandsModule.commands;
@@ -316,5 +397,297 @@ describe('Utility Commands (ls, cd, pwd)', () => {
         await commands.cd(['..']);
         expect(await commands.pwd([])).toBe('~');
     });
+  });
+
+  describe('cat', () => {
+    const catTestFile1Name = 'file1.txt';
+    const catTestFile1Content = 'Content of file1';
+    const catTestFile2Name = 'file2.txt';
+    const catTestFile2Content = 'Content of file2\nwith multiple lines.';
+    const catTestDirName = 'mydir';
+    const catTestEmptyFileName = 'empty.txt';
+
+    beforeEach(() => {
+      // Setup a specific filesystem state for cat tests
+      const catTestFs: filesystemModuleOriginal.Directory = {
+        type: 'directory',
+        name: '~',
+        children: [
+          { type: 'file', name: catTestFile1Name, content: catTestFile1Content },
+          { type: 'file', name: catTestFile2Name, content: catTestFile2Content },
+          { type: 'directory', name: catTestDirName, children: [] },
+          { type: 'file', name: catTestEmptyFileName, content: ''},
+          {
+            type: 'directory',
+            name: 'anotherdir',
+            children: [
+                { type: 'file', name: 'nestedfile.txt', content: 'Nested content' }
+            ]
+          }
+        ],
+      };
+      filesystemModule.__resetMockFsState(catTestFs);
+    });
+
+    it('should return usage message for no arguments', async () => {
+      const output = await commands.cat([]);
+      expect(output).toBe('cat: usage: cat file [...]');
+    });
+
+    it('should cat a single valid file', async () => {
+      const output = await commands.cat([catTestFile1Name]);
+      expect(output).toBe(catTestFile1Content);
+    });
+
+    it('should cat an empty file', async () => {
+      const output = await commands.cat([catTestEmptyFileName]);
+      expect(output).toBe('');
+    });
+
+    it('should cat multiple valid files, concatenating with newlines', async () => {
+      const output = await commands.cat([catTestFile1Name, catTestFile2Name]);
+      expect(output).toBe(`${catTestFile1Content}\n${catTestFile2Content}`);
+    });
+
+    it('should return error for a directory', async () => {
+      const output = await commands.cat([catTestDirName]);
+      expect(output).toBe(`cat: ${catTestDirName}: Is a directory`);
+    });
+
+    it('should return error for a non-existent file', async () => {
+      const nonExistentFile = 'nonexistent.txt';
+      const output = await commands.cat([nonExistentFile]);
+      expect(output).toBe(`cat: ${nonExistentFile}: No such file or directory`);
+    });
+
+    it('should handle a mix of valid files, directories, and non-existent files', async () => {
+      const nonExistentFile = 'nonexistent.txt';
+      const output = await commands.cat([
+        catTestFile1Name,
+        nonExistentFile,
+        catTestDirName,
+        catTestFile2Name,
+      ]);
+      const expected = [
+        catTestFile1Content,
+        `cat: ${nonExistentFile}: No such file or directory`,
+        `cat: ${catTestDirName}: Is a directory`,
+        catTestFile2Content,
+      ].join('\n');
+      expect(output).toBe(expected);
+    });
+
+    it('should correctly cat file content with newlines', async () => {
+        const output = await commands.cat([catTestFile2Name]);
+        expect(output).toBe(catTestFile2Content); // Content itself has newlines
+    });
+
+    it('should cat files using relative paths from currentDirectory', async () => {
+        // cd into 'anotherdir' which contains 'nestedfile.txt'
+        await commands.cd(['anotherdir']);
+        expect(filesystemModule.currentDirectory.name).toBe('anotherdir');
+
+        const output = await commands.cat(['nestedfile.txt']);
+        expect(output).toBe('Nested content');
+
+        // Test catting a file from parent using ..
+        const output2 = await commands.cat(['../file1.txt']);
+        expect(output2).toBe(catTestFile1Content);
+    });
+  });
+
+  describe('history', () => {
+    let enteredCommandHistoryStore: any; // Renamed to avoid conflict if tests import actual store
+
+    beforeEach(async () => {
+      localStorageMock.removeItem('enteredCommandHistory');
+      const storesModule = await import('../stores/history'); // Dynamically import for fresh state
+      enteredCommandHistoryStore = storesModule.enteredCommandHistory;
+      enteredCommandHistoryStore.set([]);
+    });
+
+    it('should return "No history yet." if history is empty', () => {
+      const output = commands.history([]);
+      expect(output).toBe('No history yet.');
+    });
+
+    it('should display history with padded line numbers', () => {
+      const cmds = ['ls -l', 'cd /documents', 'cat report.txt'];
+      enteredCommandHistoryStore.set(cmds);
+      const output = commands.history([]);
+      const expected = [
+        ' 1  ls -l',
+        ' 2  cd /documents',
+        ' 3  cat report.txt',
+      ].join('\n');
+      expect(output).toBe(expected);
+    });
+
+    it('should display history with correctly padded line numbers for > 9 items', () => {
+      const manyCommands = Array.from({ length: 12 }, (_, i) => `command ${i + 1}`);
+      enteredCommandHistoryStore.set(manyCommands);
+      const output = commands.history([]);
+      expect(output).toContain(' 1  command 1');
+      expect(output).toContain(' 9  command 9');
+      expect(output).toContain('10  command 10');
+      expect(output).toContain('12  command 12');
+    });
+
+    it('should clear history with "-c" argument and return empty string', () => {
+      enteredCommandHistoryStore.set(['cmd1', 'cmd2']);
+      localStorageMock.setItem('enteredCommandHistory', JSON.stringify(['cmd1', 'cmd2']));
+
+      const output = commands.history(['-c']);
+      expect(output).toBe('');
+
+      const currentHistory = get(enteredCommandHistoryStore);
+      expect(currentHistory.length).toBe(0);
+
+      const storedHistory = localStorageMock.getItem('enteredCommandHistory');
+      expect(storedHistory === null || storedHistory === '[]').toBe(true);
+    });
+
+    it('should display "No history yet." after clearing', () => {
+      enteredCommandHistoryStore.set(['cmd1']);
+      commands.history(['-c']); // This uses the actual store instance from commands.ts
+      // To test the effect, we need to ensure the 'history' command inside commands.ts
+      // is using the same 'enteredCommandHistoryStore' instance we are manipulating here.
+      // The dynamic import in beforeEach for 'enteredCommandHistoryStore' is for this test's direct use.
+      // The 'history' command in commands.ts uses its own imported 'enteredCommandHistory'.
+      // If `vi.resetModules()` is not run before *each test group that needs fresh stores*, this can desync.
+      // The `beforeAll` in this file runs `vi.resetModules()` once.
+      // For this test to be reliable, `commands.history` must see the cleared state.
+      // The `enteredCommandHistory.set([])` in this suite's beforeEach should affect the instance used by commands.ts
+      // because `commands.ts` imports it, and it's not separately mocked here.
+      const output = commands.history([]);
+      expect(output).toBe('No history yet.');
+    });
+
+    it('should display history if called with unknown arguments (not -c)', () => {
+      enteredCommandHistoryStore.set(['ls', 'pwd']);
+      const output = commands.history(['foo']);
+      expect(output).toContain('1  ls');
+      expect(output).toContain('2  pwd');
+    });
+  });
+
+  describe('sysinfo', () => {
+    // globalDateNowSpy is already set up. We will manipulate its mockReturnValue in tests.
+    // initialMockedDateNow is the timestamp commands.ts's startTime will get.
+    let actualThemeStore: any; // To hold dynamically imported theme store
+
+    beforeEach(async () => { // Made async for dynamic import
+      const themeModule = await import('../stores/theme');
+      actualThemeStore = themeModule.theme;
+
+      actualThemeStore.set({
+        name: 'test-theme-sysinfo',
+        foreground: '#fff',
+        background: '#000',
+        cursor: '#fff',
+        scrollback: '#000'
+      } as Theme);
+
+      // Specific window/navigator values for sysinfo tests are set in the global mocks at the top.
+      // If a test needs to deviate, it can modify globalThis.window/navigator properties here
+      // and restore them in its own afterEach. For current tests, global setup is sufficient.
+
+      // Reset Date.now spy to the initial value that commands.ts's startTime would have used.
+      // Specific tests will then advance this mock to simulate uptime.
+      globalDateNowSpy.mockReturnValue(initialMockedDateNow);
+    });
+
+    afterEach(() => {
+      // Restore Date.now spy to its original implementation (or a default mock)
+      // after the sysinfo tests are done to avoid affecting other test suites.
+      globalDateNowSpy.mockRestore();
+      // Re-establish a default mock if other tests in this file might need Date.now mocked generally.
+      // Or, if this is the last suite using it, mockRestore() is enough.
+      // For safety, let's re-establish it for any other potential tests in this file.
+      globalDateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(initialMockedDateNow);
+    });
+
+    it('should return a string containing key system information', async () => {
+      const output = await commands.sysinfo([]);
+      expect(output).toBeTypeOf('string');
+
+      // Check for ASCII art presence (e.g., first line)
+      expect(output).toContain("TTTTT WW   WW");
+
+      // Check for key information labels
+      expect(output).toContain("OS:");
+      expect(output).toContain("Host:");
+      expect(output).toContain("Kernel:");
+      expect(output).toContain("Version:");
+      expect(output).toContain("Uptime:");
+      expect(output).toContain("Shell:");
+      expect(output).toContain("Theme:");
+      expect(output).toContain("Resolution:");
+      expect(output).toContain("Terminal:");
+
+      // Check for some specific mocked values
+      expect(output).toContain("TestUAPlatform SYSINFO"); // From userAgentData
+      expect(output).toContain("testhost"); // From global window.location.hostname mock
+      expect(output).toContain("test-theme-sysinfo");
+      expect(output).toContain("1280x800 (Viewport)");
+      expect(output).toContain("Test Terminal SYSINFO");
+
+      // Initial sysinfo call for most checks
+      const initialOutput = await commands.sysinfo([]); // Use a different name for the first call
+
+      expect(initialOutput).toBeTypeOf('string');
+      // Check for ASCII art presence (e.g., first line)
+      expect(initialOutput).toContain("TTTTT WW   WW");
+
+      // Check for key information labels
+      expect(initialOutput).toContain("OS:");
+      expect(initialOutput).toContain("Host:");
+      expect(initialOutput).toContain("Kernel:");
+      expect(initialOutput).toContain("Version:");
+      // Uptime label will be checked, specific value later
+      expect(initialOutput).toContain("Uptime:");
+      expect(initialOutput).toContain("Shell:");
+      expect(initialOutput).toContain("Theme:");
+      expect(initialOutput).toContain("Resolution:");
+      expect(initialOutput).toContain("Terminal:");
+
+      // Check for some specific mocked values (OS, Host, Theme, Resolution, Terminal)
+      expect(initialOutput).toContain("OS: TestUAPlatform SYSINFO");
+      expect(initialOutput).toContain("Host: testhost");
+      expect(initialOutput).toContain("Theme: test-theme-sysinfo");
+      expect(initialOutput).toContain("Resolution: 1280x800 (Viewport)");
+      expect(initialOutput).toContain("Terminal: Test Terminal SYSINFO");
+
+      // Now specifically test precise uptime by re-calling sysinfo after setting Date.now
+      globalDateNowSpy.mockReturnValue(initialMockedDateNow + 5 * 1000);
+      const outputForUptime = await commands.sysinfo([]); // Use a new variable name
+      expect(outputForUptime).toContain("Uptime: 5s");
+    });
+
+    it('should use navigator.platform if userAgentData.platform is not available', async () => {
+        const originalNavigator = globalThis.navigator;
+        Object.defineProperty(globalThis, 'navigator', {
+            value: { platform: 'FallbackPlatformGlobal' }, // No userAgentData
+            writable: true, configurable: true
+        });
+
+        const output = await commands.sysinfo([]);
+        expect(output).toContain("OS: FallbackPlatformGlobal");
+
+        Object.defineProperty(globalThis, 'navigator', { value: originalNavigator, writable: true, configurable: true }); // Restore
+    });
+
+    it('should handle different uptime formatting (e.g. > 1 minute, > 1 hour)', async () => {
+        // Uptime: 70 seconds -> 1m 10s
+        globalDateNowSpy.mockReturnValue(initialMockedDateNow + 70 * 1000);
+        let output = await commands.sysinfo([]);
+        expect(output).toContain("Uptime: 1m 10s");
+
+        // Uptime: 3670 seconds -> 1h 1m 10s
+        globalDateNowSpy.mockReturnValue(initialMockedDateNow + 3670 * 1000);
+        output = await commands.sysinfo([]);
+        expect(output).toContain("Uptime: 1h 1m 10s");
+    });
+
   });
 });

--- a/src/utils/games/hangman.test.ts
+++ b/src/utils/games/hangman.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { startGame, guessLetter, getDisplay, __getWords, __getMaxAttempts, type HangmanState } from './hangman';
+
+describe('Hangman Game Logic', () => {
+  let initialWords: readonly string[];
+  let maxAttempts: number;
+
+  beforeEach(() => {
+    initialWords = __getWords();
+    maxAttempts = __getMaxAttempts();
+    // Reset Math.random mock for each test if specific word selection is needed
+    vi.spyOn(Math, 'random').mockRestore();
+  });
+
+  describe('startGame', () => {
+    it('should initialize a new game state correctly', () => {
+      const state = startGame();
+      expect(initialWords).toContain(state.word);
+      expect(state.guessedLetters.size).toBe(0);
+      expect(state.remainingAttempts).toBe(maxAttempts);
+      expect(state.maxAttempts).toBe(maxAttempts);
+      expect(state.status).toBe('playing');
+      expect(state.displayedWord).toBe('_'.repeat(state.word.length));
+      expect(state.lastMessage).toBe('New game started!');
+    });
+
+    it('should select a random word from the list', () => {
+      // This test is probabilistic, but we can check if words are generally different
+      const word1 = startGame().word;
+      const word2 = startGame().word;
+      const word3 = startGame().word;
+      // It's possible but unlikely they are all the same if random selection works
+      expect(initialWords.length).toBeGreaterThan(1); // Prerequisite for this test logic
+      // Basic check: are they from the list? More robust: mock Math.random
+      expect(initialWords).toContain(word1);
+      expect(initialWords).toContain(word2);
+      expect(initialWords).toContain(word3);
+    });
+
+    it('should select a specific word if Math.random is mocked', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0); // Will pick the first word
+      let state = startGame();
+      expect(state.word).toBe(initialWords[0].toLowerCase());
+
+      vi.spyOn(Math, 'random').mockReturnValue(0.5); // Example, pick a word around the middle
+      const middleIndex = Math.floor(initialWords.length * 0.5);
+      state = startGame();
+      expect(state.word).toBe(initialWords[middleIndex].toLowerCase());
+
+      vi.spyOn(Math, 'random').mockReturnValue(1 - 1e-9); // Should pick the last word
+      state = startGame();
+      expect(state.word).toBe(initialWords[initialWords.length-1].toLowerCase());
+    });
+  });
+
+  describe('guessLetter', () => {
+    let gameState: HangmanState;
+
+    beforeEach(() => {
+      // Start with a predictable word for guessLetter tests
+      vi.spyOn(Math, 'random').mockReturnValue(0); // Selects words[0]
+      gameState = startGame(); // words[0] is "svelte"
+      expect(gameState.word).toBe("svelte");
+    });
+
+    it('should not change core game state if game is already won or lost, only message', () => {
+      const originalWonState: HangmanState = { ...gameState, status: 'won' };
+      let nextState = guessLetter('a', originalWonState);
+
+      expect(nextState.word).toBe(originalWonState.word);
+      expect(nextState.guessedLetters).toEqual(originalWonState.guessedLetters);
+      expect(nextState.remainingAttempts).toBe(originalWonState.remainingAttempts);
+      expect(nextState.displayedWord).toBe(originalWonState.displayedWord);
+      expect(nextState.status).toBe('won');
+      expect(nextState.lastMessage).toBe("Game over. Start a new game.");
+
+      const originalLostState: HangmanState = { ...gameState, status: 'lost' };
+      nextState = guessLetter('a', originalLostState);
+      expect(nextState.word).toBe(originalLostState.word);
+      expect(nextState.guessedLetters).toEqual(originalLostState.guessedLetters);
+      expect(nextState.remainingAttempts).toBe(originalLostState.remainingAttempts);
+      expect(nextState.displayedWord).toBe(originalLostState.displayedWord);
+      expect(nextState.status).toBe('lost');
+      expect(nextState.lastMessage).toBe("Game over. Start a new game.");
+    });
+
+    it('should return current state for invalid guess (non-letter, multiple chars)', () => {
+      let state = guessLetter('1', gameState);
+      expect(state.guessedLetters.size).toBe(0);
+      expect(state.remainingAttempts).toBe(maxAttempts);
+      expect(state.lastMessage).toContain("Invalid guess");
+
+      state = guessLetter('ab', gameState);
+      expect(state.guessedLetters.size).toBe(0);
+      expect(state.remainingAttempts).toBe(maxAttempts);
+      expect(state.lastMessage).toContain("Invalid guess");
+    });
+
+    it('should return current state if letter already guessed (case insensitive)', () => {
+      gameState = guessLetter('s', gameState); // First guess
+      const stateAfterFirstGuess = { ...gameState };
+      gameState = guessLetter('S', gameState); // Second guess (same letter, different case)
+
+      expect(gameState.guessedLetters).toEqual(stateAfterFirstGuess.guessedLetters);
+      expect(gameState.remainingAttempts).toBe(stateAfterFirstGuess.remainingAttempts);
+      expect(gameState.lastMessage).toContain("already guessed");
+    });
+
+    it('should handle correct guess', () => {
+      gameState = guessLetter('s', gameState);
+      expect(gameState.guessedLetters.has('s')).toBe(true);
+      expect(gameState.displayedWord).toBe('s_____');
+      expect(gameState.remainingAttempts).toBe(maxAttempts); // No attempts lost
+      expect(gameState.status).toBe('playing');
+      expect(gameState.lastMessage).toContain("Correct guess: 's'");
+    });
+
+    it('should handle incorrect guess', () => {
+      gameState = guessLetter('a', gameState); // 'a' is not in "svelte"
+      expect(gameState.guessedLetters.has('a')).toBe(true);
+      expect(gameState.displayedWord).toBe('______'); // Unchanged
+      expect(gameState.remainingAttempts).toBe(maxAttempts - 1);
+      expect(gameState.status).toBe('playing');
+      expect(gameState.lastMessage).toContain("Incorrect guess: 'a'");
+    });
+
+    it('should update status to "won" when word is fully guessed', () => {
+      // "svelte"
+      gameState = guessLetter('s', gameState);
+      gameState = guessLetter('v', gameState);
+      gameState = guessLetter('e', gameState);
+      gameState = guessLetter('l', gameState);
+      gameState = guessLetter('t', gameState); // Last letter
+
+      expect(gameState.status).toBe('won');
+      expect(gameState.displayedWord).toBe('svelte');
+      expect(gameState.lastMessage).toContain(`You won! The word was: svelte`);
+    });
+
+    it('should update status to "lost" when remainingAttempts is 0', () => {
+      const wrongLetters = ['a', 'b', 'c', 'd', 'f', 'g']; // 6 wrong guesses
+      for (const letter of wrongLetters) {
+        gameState = guessLetter(letter, gameState);
+      }
+      expect(gameState.status).toBe('lost');
+      expect(gameState.remainingAttempts).toBe(0);
+      expect(gameState.lastMessage).toContain(`You lost! The word was: svelte`);
+    });
+  });
+
+  describe('getDisplay', () => {
+    beforeEach(() => {
+      // Ensure predictable word for getDisplay tests
+      vi.spyOn(Math, 'random').mockReturnValue(0); // Selects words[0] ("svelte")
+    });
+
+    it('should format display for "playing" state', () => {
+      let state = startGame(); // word "svelte"
+      state = guessLetter('s', state); // s correct
+      state = guessLetter('a', state); // a incorrect
+
+      const display = getDisplay(state);
+      expect(state.word).toBe("svelte"); // Confirm word for sanity
+      expect(state.displayedWord).toBe("s_____"); // After 's' and 'a' (incorrect)
+      expect(state.lastMessage).toBe("Incorrect guess: 'a'.");
+
+      expect(display).toContain("Word: s _ _ _ _ _");
+      expect(display).toContain("Guessed: a, s");
+      expect(display).toContain(`Attempts left: ${maxAttempts - 1}/${maxAttempts}`);
+      expect(display).toContain(state.lastMessage); // Should show message from last guess
+      // Check for part of hangman art for 1 wrong guess
+      expect(display).toContain("  O   |");
+    });
+
+    it('should format display for "won" state', () => {
+      let state = startGame(); // "svelte"
+      state = guessLetter('s', state);
+      state = guessLetter('v', state);
+      state = guessLetter('e', state);
+      state = guessLetter('l', state);
+      state = guessLetter('t', state); // Win
+
+      const display = getDisplay(state);
+      expect(display).toContain("Word: s v e l t e");
+      expect(display).toContain(`Guessed: e, l, s, t, v`);
+      expect(display).toContain(`Attempts left: ${maxAttempts}/${maxAttempts}`);
+      expect(display).toContain("You won! The word was: svelte");
+    });
+
+    it('should format display for "lost" state', () => {
+      let state = startGame(); // "svelte"
+      const wrongLetters = ['a', 'b', 'c', 'd', 'f', 'g']; // 6 wrong guesses
+      for (const letter of wrongLetters) {
+        state = guessLetter(letter, state);
+      }
+
+      const display = getDisplay(state);
+      expect(display).toContain("Word: _ _ _ _ _ _"); // Or whatever unguessed part was, if any
+      expect(display).toContain(`Guessed: a, b, c, d, f, g`);
+      expect(display).toContain(`Attempts left: 0/${maxAttempts}`);
+      expect(display).toContain("You lost! The word was: svelte");
+      // Check for full hangman art
+      expect(display).toContain("/ \\  |");
+    });
+  });
+});

--- a/src/utils/games/hangman.ts
+++ b/src/utils/games/hangman.ts
@@ -1,0 +1,145 @@
+const words = ["svelte", "typescript", "terminal", "javascript", "hangman", "developer", "interface", "component"];
+const MAX_ATTEMPTS = 6;
+
+export interface HangmanState {
+  word: string;
+  guessedLetters: Set<string>;
+  remainingAttempts: number;
+  maxAttempts: number;
+  status: 'playing' | 'won' | 'lost';
+  displayedWord: string;
+  lastMessage?: string; // Optional message for feedback like "Already guessed"
+}
+
+function generateDisplayedWord(word: string, guessedLetters: Set<string>): string {
+  return word.split('').map(char => (guessedLetters.has(char.toLowerCase()) ? char : '_')).join('');
+}
+
+export function startGame(): HangmanState {
+  const randomIndex = Math.floor(Math.random() * words.length);
+  const chosenWord = words[randomIndex].toLowerCase(); // Ensure word is lowercase for consistent guessing
+
+  return {
+    word: chosenWord,
+    guessedLetters: new Set<string>(),
+    remainingAttempts: MAX_ATTEMPTS,
+    maxAttempts: MAX_ATTEMPTS,
+    status: 'playing',
+    displayedWord: generateDisplayedWord(chosenWord, new Set<string>()),
+    lastMessage: 'New game started!'
+  };
+}
+
+export function guessLetter(letter: string, currentState: HangmanState): HangmanState {
+  if (currentState.status !== 'playing') {
+    return { ...currentState, lastMessage: "Game over. Start a new game." };
+  }
+
+  const normalizedLetter = letter.toLowerCase();
+  if (normalizedLetter.length !== 1 || !/^[a-z]$/.test(normalizedLetter)) {
+    return { ...currentState, lastMessage: "Invalid guess. Please enter a single letter." };
+  }
+
+  if (currentState.guessedLetters.has(normalizedLetter)) {
+    return { ...currentState, lastMessage: `Letter '${normalizedLetter}' already guessed.` };
+  }
+
+  const newGuessedLetters = new Set(currentState.guessedLetters).add(normalizedLetter);
+  let newRemainingAttempts = currentState.remainingAttempts;
+  let message = "";
+
+  if (!currentState.word.includes(normalizedLetter)) {
+    newRemainingAttempts--;
+    message = `Incorrect guess: '${normalizedLetter}'.`;
+  } else {
+    message = `Correct guess: '${normalizedLetter}'.`;
+  }
+
+  const newDisplayedWord = generateDisplayedWord(currentState.word, newGuessedLetters);
+  let newStatus = currentState.status;
+
+  if (newDisplayedWord === currentState.word) {
+    newStatus = 'won';
+    message = `You won! The word was: ${currentState.word}`;
+  } else if (newRemainingAttempts === 0) {
+    newStatus = 'lost';
+    message = `You lost! The word was: ${currentState.word}`;
+  }
+
+  return {
+    ...currentState,
+    guessedLetters: newGuessedLetters,
+    remainingAttempts: newRemainingAttempts,
+    displayedWord: newDisplayedWord,
+    status: newStatus,
+    lastMessage: message
+  };
+}
+
+export function getDisplay(state: HangmanState): string {
+  const hangmanArt = [
+    "  +---+\n  |   |\n      |\n      |\n      |\n      |\n=========", // 0 attempts left (full hangman)
+    "  +---+\n  |   |\n  O   |\n      |\n      |\n      |\n=========", // 1
+    "  +---+\n  |   |\n  O   |\n  |   |\n      |\n      |\n=========", // 2
+    "  +---+\n  |   |\n  O   |\n /|   |\n      |\n      |\n=========", // 3
+    "  +---+\n  |   |\n  O   |\n /|\\  |\n      |\n      |\n=========", // 4
+    "  +---+\n  |   |\n  O   |\n /|\\  |\n /    |\n      |\n=========", // 5
+    "  +---+\n  |   |\n  O   |\n /|\\  |\n / \\  |\n      |\n=========", // 6 - this is actually game over state (lost)
+  ];
+
+  // The art should represent incorrect guesses made. So, index is maxAttempts - remainingAttempts.
+  // However, the art stages are usually 0 to 6 (7 stages).
+  // If maxAttempts is 6, then 6 incorrect guesses means 0 remaining attempts.
+  // Stage 0: initial state (no incorrect guesses)
+  // Stage 1: 1 incorrect guess (5 remaining)
+  // ...
+  // Stage 6: 6 incorrect guesses (0 remaining) -> full hangman
+
+  // Let's adjust the art array to match remainingAttempts more intuitively.
+  // The art represents the state *after* N incorrect guesses.
+  // remaining = 6 (0 incorrect) -> art[6] (empty gallows or some initial state)
+  // remaining = 0 (6 incorrect) -> art[0] (full hangman)
+  // So, the index for art should be state.remainingAttempts.
+  // Let's redefine art so index = (maxAttempts - remainingAttempts)
+  const HANGMAN_STAGES = [
+    "  +---+\n  |   |\n      |\n      |\n      |\n      |\n=========", // 0 incorrect guesses
+    "  +---+\n  |   |\n  O   |\n      |\n      |\n      |\n=========", // 1 incorrect
+    "  +---+\n  |   |\n  O   |\n  |   |\n      |\n      |\n=========", // 2 incorrect
+    "  +---+\n  |   |\n  O   |\n /|   |\n      |\n      |\n=========", // 3 incorrect
+    "  +---+\n  |   |\n  O   |\n /|\\  |\n      |\n      |\n=========", // 4 incorrect
+    "  +---+\n  |   |\n  O   |\n /|\\  |\n /    |\n      |\n=========", // 5 incorrect
+    "  +---+\n  |   |\n  O   |\n /|\\  |\n / \\  |\n      |\n========="  // 6 incorrect (lost)
+  ];
+
+  const artIndex = Math.min(state.maxAttempts - state.remainingAttempts, HANGMAN_STAGES.length - 1);
+  const currentArt = HANGMAN_STAGES[artIndex];
+
+  const displayLines: string[] = [];
+  displayLines.push(currentArt);
+  displayLines.push(`\nWord: ${state.displayedWord.split('').join(' ')}`);
+  displayLines.push(`Guessed: ${Array.from(state.guessedLetters).sort().join(', ')}`);
+  displayLines.push(`Attempts left: ${state.remainingAttempts}/${state.maxAttempts}`);
+
+  if (state.lastMessage) {
+    displayLines.push(`\n${state.lastMessage}`);
+  }
+
+  // Status message is now part of lastMessage if game ends.
+  // If still playing and no specific lastMessage, could say "Playing..."
+  if (state.status === 'playing' && !state.lastMessage) {
+    displayLines.push("Status: Playing...");
+  }
+
+  return displayLines.join('\n');
+}
+
+// Function for testing purposes to reset internal state (if any non-HangmanState state existed)
+// For now, Hangman is purely functional based on HangmanState, so no global module state to reset here.
+// If we were to store words list globally and modify it, then we'd need a reset.
+// Math.random is a global dependency that tests might want to mock.
+export function __getWords(): readonly string[] { // For testing word selection
+    return words;
+}
+export function __getMaxAttempts(): number { // For testing setup
+    return MAX_ATTEMPTS;
+}


### PR DESCRIPTION
This commit introduces several new features to enhance the terminal's capabilities and provide some fun:

1.  **`cat` Command:**
    *   Allows you to view the content of files within the virtual file system.
    *   Supports multiple file arguments.
    *   Handles errors for directories and non-existent files.

2.  **`history` Command:**
    *   Displays the list of previously entered commands, with line numbers.
    *   Supports `history -c` to clear the command history.

3.  **`sysinfo` Command:**
    *   A neofetch/screenfetch-like command that displays system information (e.g., OS, Host, Theme, Uptime, Version) alongside a small ASCII art logo.

4.  **Hangman Game:**
    *   A classic text-based Hangman game accessible via the `hangman` command.
    *   You can start a new game and guess letters.
    *   The game tracks attempts, displays the current word status, and includes ASCII art for the hangman figure.

All new features include comprehensive unit tests, and all existing tests continue to pass.